### PR TITLE
Add publish.sh and documentation updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ROYGBIV creates Lightning prisms, which are BOLT 12 offers that split Lightning payments to different parties at percentages you define.
 
-This repository contains a progressive web app - the frontend component to ROYGBIV. The backend plugin is available [here](https://github.com/daGoodenough/ROYGBIV-backend) and requires Core Lightning with the runtime flag 'experimental-dual-fund.'
+This repository contains a progressive web app - the frontend component to ROYGBIV. The backend plugin is available [here](https://github.com/farscapian/clams-app-docker/blob/main/roygbiv/cln-plugins/prism-plugin.py) and requires Core Lightning with the runtime flag 'experimental-dual-fund.'
 
 BOLT 12 offers are static QR payment codes that can be reused again and again. Currently, ROYGBIV supports prism payouts to node pubkeys via keysend.
 
@@ -39,4 +39,4 @@ npm run dev
 
 4. Open [http://localhost:5173](http://localhost:5173) in your browser
 
-5. Follow the instructions at [https://github.com/farscapian/clams-app-docker](https://github.com/farscapian/clams-app-docker) to set up the backend
+5. This app requires a core lightning backend. You can bring your own core lightning backend, or use [this repo](https://github.com/farscapian/clams-app-docker) that was used to create (roygbiv.money)[https://roygbiv.money].

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+cd "$(dirname "$0")"
+
+ENVIRONMENT_LIST_CSV="local.env"
+
+# grab any modifications from the command line.
+for i in "$@"; do
+    case $i in
+        --environments-csv=*)
+            ENVIRONMENT_LIST_CSV="${i#*=}"
+            shift
+        ;;
+        *)
+        ;;
+    esac
+done
+
+# we run a git push to push the front-end changes to origin main branch.
+#git push
+
+cd ..
+
+if [ ! -d "./clams-app-docker" ]; then
+    git clone https://github.com/farscapian/clams-app-docker "$CLAMS_DOCKER_APP_PATH"
+fi
+
+cd ./clams-app-docker
+git pull
+
+# Use IFS to set the delimiter to comma
+IFS=','
+
+# get the active_env value that's in there before we run our script.
+STARTING_ACTIVE_ENV=$(cat ./active_env.txt | head -n1 | awk '{print $1;}')
+
+# loop over each active env and run up.sh
+for ACTIVE_ENV in $ENVIRONMENT_LIST_CSV; do
+    echo -n "$ACTIVE_ENV" > ./active_env.txt
+    ./reset.sh "$@"
+done
+
+echo -n "$STARTING_ACTIVE_ENV" > ./active_env.txt


### PR DESCRIPTION
This pull request contains publish.sh. The intent here is that when you're done developing the ROYGBIV-frontend application and you're ready to push to main, you can run publish.sh instead. The script pulls down the latest updates from the main branch of the clams-docker-app, then iterates over all the user-defined environments, running reset.sh. Here's the syntax:

./publish.sh --environments-csv="local.env,roygbiv.money,rogbiv.team"

The parameter there specifies all the environments that you want to have updates. Please refer to the [readme.md](https://github.com/farscapian/clams-app-docker#roygbiv-stack) for more information about using that repo.